### PR TITLE
ci: skip 48-job build matrix on doc-only PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,43 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      code: ${{ steps.check.outputs.code }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - name: Check for code changes
+        id: check
+        run: |
+          # Push to main ve workflow_call (release akışı) → her zaman full build
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Non-PR event, running full build"
+            exit 0
+          fi
+          # PR: doc-only mı kontrol et (negated pathspec: doc dışı değişiklik var mı?)
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          if git diff --quiet "$BASE...$HEAD" -- \
+            ':!**/*.md' ':!docs/**' ':!_bmad-output/**' \
+            ':!LICENSE' ':!COPYING' ':!.gitattributes' \
+            ':!.github/ISSUE_TEMPLATE/**' ':!.github/PULL_REQUEST_TEMPLATE/**' \
+            ':!.github/release-notes-template.md'; then
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Documentation-only change — skipping build & test matrix"
+          else
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     name: Build (${{ matrix.os }}, Java ${{ matrix.java }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -105,7 +141,8 @@ jobs:
 
   gui-tests:
     name: GUI Tests (${{ matrix.os }}, Java ${{ matrix.java }})
-    needs: build
+    needs: [changes, build]
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -229,3 +266,25 @@ jobs:
           path: freemind/build/test-results/testGui/*.xml
           reporter: java-junit
           fail-on-empty: false
+
+  ci:
+    name: CI
+    if: always()
+    needs: [changes, build, gui-tests]
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Evaluate results
+        run: |
+          echo "Code changed: ${{ needs.changes.outputs.code }}"
+          echo "Build: ${{ needs.build.result }}"
+          echo "GUI Tests: ${{ needs.gui-tests.result }}"
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "::error::One or more jobs failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "::error::One or more jobs were cancelled"
+            exit 1
+          fi
+          echo "All checks passed"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,16 @@ name: Release Please
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '_bmad-output/**'
+      - 'LICENSE'
+      - 'COPYING'
+      - '.gitattributes'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - '.github/release-notes-template.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,6 +5,16 @@ on:
     - cron: '0 7 * * 1'  # Monday 7am UTC
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '_bmad-output/**'
+      - 'LICENSE'
+      - 'COPYING'
+      - '.gitattributes'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - '.github/release-notes-template.md'
   workflow_dispatch:
 
 permissions: read-all

--- a/README-TR.md
+++ b/README-TR.md
@@ -5,6 +5,8 @@
 [![Build Status](https://github.com/Denomas/freemind-ce/actions/workflows/build.yml/badge.svg)](https://github.com/Denomas/freemind-ce/actions)
 [![Java 21](https://img.shields.io/badge/Java-21-orange.svg)](https://adoptium.net/)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Denomas/freemind-ce/badge)](https://scorecard.dev/viewer/?uri=github.com/Denomas/freemind-ce)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12156/badge)](https://www.bestpractices.dev/projects/12156)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 [![Platforms](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey.svg)](https://github.com/Denomas/freemind-ce/releases/latest)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Denomas/freemind-ce/badge)](https://scorecard.dev/viewer/?uri=github.com/Denomas/freemind-ce)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12156/badge)](https://www.bestpractices.dev/projects/12156)
 
 ---
 


### PR DESCRIPTION
## Summary
- Add pure `git diff` based path filtering to `build.yml` — doc-only PRs skip the 48-job build/test matrix entirely
- Add `CI` aggregator job as single required check (replaces 48 individual checks)
- Add `paths-ignore` to `release-please.yml` and `scorecard.yml` for doc-only pushes to main
- Add OpenSSF Best Practices badge to README.md and README-TR.md

## How it works

```
PR (code change):   changes(code=true)  → build(24) → gui-tests(24) → ci ✅
PR (docs only):     changes(code=false) → build(SKIP) → gui-tests(SKIP) → ci ✅
Push to main:       changes(code=true)  → build(24) → gui-tests(24) → ci ✅
workflow_call:      changes(code=true)  → build(24) → gui-tests(24) → ci ✅
```

No 3rd-party actions — uses negated git pathspecs to detect doc-only changes (same pattern as astral-sh/ruff, vercel/next.js).

## Follow-up (after merge)
- [ ] Update GitHub ruleset `main-protection`: replace 48 individual required checks with single `CI` check

## Test plan
- [ ] Verify this PR triggers full 48-job matrix (contains workflow changes = code change)
- [ ] Open a doc-only PR after merge → verify build/gui-tests are skipped, CI passes in ~30s
- [ ] Verify push-to-main still runs full build via release-please workflow_call